### PR TITLE
JNG-4289 Division on derived returns different value for PSQL vs HSQL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <cxf-version>3.4.4</cxf-version>
         <pax-exam-version>4.13.4</pax-exam-version>
 
-        <judo-meta-expression-version>1.0.5.20230201_041534_ffcfa727_develop</judo-meta-expression-version>
+        <judo-meta-expression-version>1.0.5.20230221_180247_8be5a060_feature_JNG_4289_Division_on_derived_returns_different_value_for_PSQL_vs_HSQL</judo-meta-expression-version>
         <judo-meta-psm-version>1.2.4.20230207_042332_0fff9a62_develop</judo-meta-psm-version>
         <judo-meta-jql-version>1.0.4.20230131_040907_eb2d118a_develop</judo-meta-jql-version>
         <judo-meta-measure-version>1.0.2.20230207_042013_39921fb5_develop</judo-meta-measure-version>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-4289" title="JNG-4289" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-4289</a>  Division on derived returns different value for PSQL vs HSQL
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
JNG-4289 Division on derived returns different value for PSQL vs HSQL